### PR TITLE
Trim process name to 32 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,7 @@ All notable changes to the "zxdb" extension will be documented in this file.
 ## [1.0.0]
 
 - Marketplace release
+
+## [1.0.1]
+
+- Trim process name to 32 characters. Update Readme.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 provides IDE based [zxdb](https://fuchsia.dev/fuchsia-src/development/debugger?hl=en) debugger
 support for developers working with the open source [Fuchsia](https://fuchsia.dev/) operating system.
 
+Note: This is not an officially supported Google product
+
 ## Features
 
 - One click debugging - Press **F5** to start debugging on Fuchsia devices.
@@ -25,6 +27,10 @@ support for developers working with the open source [Fuchsia](https://fuchsia.de
    [VS Code setup for Fuchsia](https://fuchsia.dev/fuchsia-src/development/editors/vscode?hl=en).
 
 ## Quick start
+
+- **Step 0:** Open VS Code application and install **zxdb** extension from marketplace
+  (Click **View** then **Extensions** and search for **zxdb**, select **zxdb** and click on
+  **install**).
 
 - **Step 1:** Make sure that the target device is running fuchsia and the package server
   (like `fx serve`) has started on the development host. Make sure to have installed the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "zxdb",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "zxdb",
   "displayName": "zxdb",
   "description": "Fuchsia debugger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "fuchsia-authors",
   "license": "Apache-2.0",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -93,9 +93,10 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {}
 
 class ZxdbConfigurationProvider implements vscode.DebugConfigurationProvider {
+  maxFilterNameLength = 32;
   // This method is called just before launching debug session.
   // Final updates to debug configuration can be done here.
-  resolveDebugConfiguration(
+  resolveDebugConfigurationWithSubstitutedVariables(
       folder: WorkspaceFolder|undefined, config: DebugConfiguration,
       token?: CancellationToken): ProviderResult<DebugConfiguration> {
     // if launch.json is missing or empty
@@ -105,6 +106,13 @@ class ZxdbConfigurationProvider implements vscode.DebugConfigurationProvider {
           'added automatically, if not add it manually (Hint: Add Configuration -> zxdb...).\n' +
           'Next, pick a configuration in the launch configuration dropdown to start debugging.');
       return null;
+    }
+
+    if (config.process.length > this.maxFilterNameLength) {
+      config.process = config.process.substring(0, this.maxFilterNameLength);
+      log.warn(
+          'Process name too long. It will be trimmed to "' + config.process +
+          '"');
     }
 
     if (config.request === 'attach') {


### PR DESCRIPTION
This is the length of process names in zircon. A warning is raised
if the user entered a larger process name.